### PR TITLE
Avoid NoneType exception in Experiment constructor

### DIFF
--- a/pyml_experiments/Experiment.py
+++ b/pyml_experiments/Experiment.py
@@ -1,4 +1,5 @@
 import datetime
+import writers
 
 class Experiment(object):
 
@@ -13,6 +14,8 @@ class Experiment(object):
         self.values={}
         self.current_scope=[]
 
+        if writer is None:
+            writer = writers.StdoutWriter()
         self.writer=writer
         self.writer.begin(arguments=arguments)
 

--- a/pyml_experiments/test_experiment.py
+++ b/pyml_experiments/test_experiment.py
@@ -1,0 +1,6 @@
+from Experiment import Experiment
+
+def test_can_build_Experiment_without_writer():
+    # don't pass any writer. The goal is to ensure that it doesn't throw
+    Experiment(arguments= {"foo": "bar"})
+


### PR DESCRIPTION
The default value of writer in the Experiment constructor is None.
Notwithstanding, we call its `begin` method.

This patch sets a sane default (stdout writer).
It should make the first contact with this library more smooth.